### PR TITLE
Fix teamcoach hook cascade causing runaway processes

### DIFF
--- a/.claude/hooks/teamcoach-stop.py
+++ b/.claude/hooks/teamcoach-stop.py
@@ -19,6 +19,11 @@ from datetime import datetime
 def invoke_teamcoach():
     """Invoke TeamCoach agent for session analysis."""
     
+    # CRITICAL: Check for cascade prevention flag
+    if os.environ.get('CLAUDE_HOOK_EXECUTION', '0') == '1':
+        print("🛡️ Cascade prevention: TeamCoach hook skipped during hook execution")
+        return True
+    
     # Create TeamCoach prompt for session analysis
     teamcoach_prompt = """
 Task: Analyze completed session and provide team coaching recommendations
@@ -48,10 +53,14 @@ Mode: Post-session analysis with focus on continuous improvement
 """.strip()
 
     try:
-        # Invoke TeamCoach using Claude Code CLI
+        # Set cascade prevention environment variable
+        env = os.environ.copy()
+        env['CLAUDE_HOOK_EXECUTION'] = '1'
+        
+        # Invoke TeamCoach using Claude Code CLI with cascade prevention
         result = subprocess.run([
             'claude', '/agent:teamcoach', teamcoach_prompt
-        ], capture_output=True, text=True, timeout=300)  # 5 minute timeout
+        ], capture_output=True, text=True, timeout=300, env=env)  # 5 minute timeout
         
         if result.returncode == 0:
             print(f"✅ TeamCoach analysis completed successfully")

--- a/.claude/hooks/teamcoach-subagent-stop.py
+++ b/.claude/hooks/teamcoach-subagent-stop.py
@@ -19,6 +19,11 @@ from datetime import datetime
 def invoke_teamcoach_agent_analysis(agent_data):
     """Invoke TeamCoach for specific agent performance analysis."""
     
+    # CRITICAL: Check for cascade prevention flag
+    if os.environ.get('CLAUDE_HOOK_EXECUTION', '0') == '1':
+        print("🛡️ Cascade prevention: TeamCoach subagent hook skipped during hook execution")
+        return True
+    
     # Extract agent information from hook input
     agent_name = agent_data.get('agent_name', 'unknown-agent')
     task_result = agent_data.get('result', 'unknown')
@@ -53,10 +58,14 @@ Agent: {agent_name}
 """.strip()
 
     try:
-        # Invoke TeamCoach using Claude Code CLI
+        # Set cascade prevention environment variable
+        env = os.environ.copy()
+        env['CLAUDE_HOOK_EXECUTION'] = '1'
+        
+        # Invoke TeamCoach using Claude Code CLI with cascade prevention
         result = subprocess.run([
             'claude', '/agent:teamcoach', teamcoach_prompt
-        ], capture_output=True, text=True, timeout=180)  # 3 minute timeout
+        ], capture_output=True, text=True, timeout=180, env=env)  # 3 minute timeout
         
         if result.returncode == 0:
             print(f"✅ TeamCoach agent analysis completed for {agent_name}")


### PR DESCRIPTION
## Problem Fixed

This PR fixes the critical issue where teamcoach hooks were creating a cascade effect that spawned hundreds of runaway processes (Issue #63).

## Root Cause

The teamcoach hooks were calling `claude /agent:teamcoach` via subprocess, which triggered new Claude sessions. These new sessions would invoke the same stop hooks when they ended, creating an infinite loop of process spawning.

## Solution

Implemented a cascade prevention mechanism using the `CLAUDE_HOOK_EXECUTION` environment variable:

### Changes Made

1. **teamcoach-stop.py**: Added cascade prevention check
   - Skips execution when `CLAUDE_HOOK_EXECUTION=1`
   - Sets the flag when invoking Claude CLI to prevent recursion

2. **teamcoach-subagent-stop.py**: Added same cascade prevention
   - Same protection mechanism for subagent hook
   - Prevents recursive execution loops

### How It Works

- When hooks execute normally, they proceed as intended
- When a hook calls the Claude CLI, it sets `CLAUDE_HOOK_EXECUTION=1`
- Any hooks triggered by the new Claude session detect this flag and skip execution
- This breaks the cascade loop while preserving normal functionality

## Testing

✅ Tested cascade prevention with `CLAUDE_HOOK_EXECUTION=1` - both hooks properly skip
✅ Verified both hooks display appropriate cascade prevention messages
✅ No more runaway processes spawning

## Impact

- ✅ Stops runaway process creation
- ✅ Preserves normal hook functionality  
- ✅ Protects system resources
- ✅ Makes hook system stable and reliable

Fixes #63