### PR TITLE
fix: migrate Claude hooks to project-level configuration with relative paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,46 @@
 {
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/xpia_web_validator.py"
+          }
+        ]
+      },
+      {
+        "matcher": "WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/xpia_web_validator.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/xpia_web_validator.py"
+          }
+        ]
+      },
+      {
+        "matcher": "WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/xpia_web_validator.py"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "additionalDirectories": [
       "/tmp"


### PR DESCRIPTION
## Summary
Migrates Claude Code hooks from global settings to project-level configuration using relative paths for better portability.

## Problem
- Hooks were configured in global settings (~/.claude/settings.json)
- Used absolute paths pointing to different project directory
- Caused startup warnings when scripts couldn't be found

## Solution
- ✅ Removed hooks from global Claude settings
- ✅ Added hooks to project-level .claude/settings.json
- ✅ Used relative paths for better portability
- ✅ Configured PreToolUse and PostToolUse hooks for WebFetch and WebSearch

## Changes
- Updated `~/.claude/settings.json` to remove hook configuration
- Updated `.claude/settings.json` to add hooks with relative paths
- Hooks now reference `.claude/hooks/xpia_web_validator.py` using relative path

## Testing
- Pre-commit hooks passed
- Configuration uses standard Claude Code hook format
- Relative paths ensure portability across environments

Fixes #152

*Note: This PR was created by an AI agent on behalf of the repository owner.*