### PR TITLE
Fix orchestrator CLI import errors

### DIFF
--- a/.claude/orchestrator/orchestrator_main.py
+++ b/.claude/orchestrator/orchestrator_main.py
@@ -43,8 +43,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "shared"))
 try:
     from github_operations import GitHubOperations
     from state_management import StateManager, CheckpointManager
-    from utils.error_handling import ErrorHandler, CircuitBreaker, RetryManager
-    from task_tracking import TaskMetrics, WorkflowPhase
+    from utils.error_handling import ErrorHandler, CircuitBreaker
+    from task_tracking import TaskMetrics
     from interfaces import AgentConfig, OperationResult
 except ImportError as e:
     logging.warning(f"Could not import shared modules: {e}")


### PR DESCRIPTION
## Summary
- Fixed import errors preventing orchestrator CLI from starting
- Removed non-existent imports that have local fallback definitions

## Changes
- Removed `RetryManager` from `utils.error_handling` import (doesn't exist in module)
- Removed `WorkflowPhase` from `task_tracking` import (doesn't exist in module) 
- Both classes have local fallback definitions in orchestrator_main.py

## Test Results
Orchestrator CLI now starts successfully without import warnings:
```bash
$ python3 .claude/orchestrator/orchestrator_cli.py --help
# No warnings, shows help successfully
```

## Impact
- Orchestrator agent can now be used properly
- Unblocks all workflow automation that depends on the orchestrator
- Enables parallel task execution as designed

Fixes #155

*Note: This PR was created by an AI agent on behalf of the repository owner.*

🤖 Generated with [Claude Code](https://claude.ai/code)