### PR TITLE
fix: resolve architect engine type errors (4 → 0 errors)

### DIFF
--- a/gadugi-v0.3/src/orchestrator/architect_engine.py
+++ b/gadugi-v0.3/src/orchestrator/architect_engine.py
@@ -268,10 +268,10 @@ class ArchitectureResponse:
     """Complete architecture response."""
 
     success: bool
-    architecture: Architecture
-    implementation_plan: ImplementationPlan
-    technical_specifications: TechnicalSpecifications
-    quality_attributes: QualityAttributes
+    architecture: Architecture | None
+    implementation_plan: ImplementationPlan | None
+    technical_specifications: TechnicalSpecifications | None
+    quality_attributes: QualityAttributes | None
     recommendations: list[Recommendation]
     risks_and_mitigations: list[Risk]
     error_message: str | None = None


### PR DESCRIPTION
## Summary
- Fixed all 4 pyright errors in architect_engine.py
- Made ArchitectureResponse fields optional for error handling
- Fixed constructor parameter types

## Changes
- ArchitectureResponse fields now Optional for error scenarios
- Proper error response construction
- Type-safe failure handling

Part of pyright type safety campaign.

*Note: This PR was created by an AI agent on behalf of the repository owner.*

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>