### PR TITLE
docs: add PR merge approval policy to project instructions

### DIFF
--- a/.github/Memory.md
+++ b/.github/Memory.md
@@ -34,6 +34,7 @@
 - Update README.md with new installation instructions
 
 ## Important Notes
+- **PR Merge Policy**: NEVER merge PRs without explicit user approval - always wait for user to say "merge it" or similar
 - All Gadugi files must go in .claude/ directory (complete isolation)
 - One-line install: curl -fsSL https://raw.githubusercontent.com/rysweet/gadugi/main/install.sh | sh
 - Focus on reliability and robustness over features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Use worktrees for:
    - Push branch from within worktree
    - Create PR using `gh pr create` from worktree directory
    - Reference issue number in PR description
+   - **CRITICAL: Never merge PRs without explicit user approval** (see PR Merge Policy below)
 
 4. **Cleanup Phase**:
    - After PR is merged, remove worktree:
@@ -275,6 +276,50 @@ The worktree-manager agent handles:
 - Integration with orchestrator for parallel work
 
 Use worktrees whenever working on issues to maintain clean, isolated development environments.
+
+## PR Merge Approval Policy
+
+**⚠️ CRITICAL: NEVER merge PRs without explicit user approval**
+
+### Required Workflow for PR Completion
+
+1. **Create PR** - Use `gh pr create` with proper description
+2. **Execute Code Review** - Phase 9 with code-reviewer agent
+3. **Address Feedback** - Phase 10 with review response
+4. **STOP AND WAIT** - Report PR status to user
+5. **Only merge when user explicitly says to** - Wait for "merge it", "please merge", or similar
+
+### Correct Pattern
+```
+Assistant: "PR #123 has passed review and all checks are green. 
+          Ready for merge. Awaiting your approval to proceed."
+User: "Please merge it"
+Assistant: [Now executes: gh pr merge 123]
+```
+
+### Incorrect Pattern (DO NOT DO THIS)
+```
+Assistant: "PR passed review, merging now..."  ❌
+Assistant: [Auto-merges without asking]        ❌
+```
+
+### Why This Policy Exists
+- User maintains control over main branch
+- Allows final review before merge
+- Prevents unwanted changes from entering production
+- Ensures user awareness of all merges
+
+### Commands Reference
+```bash
+# View PR status (always allowed)
+gh pr view <pr-number>
+gh pr checks <pr-number>
+
+# Merge PR (ONLY with explicit user approval)
+gh pr merge <pr-number> --merge --delete-branch
+```
+
+Remember: Even if all checks pass and review is approved, ALWAYS wait for explicit user permission before merging.
 
 ## UV Virtual Environment Setup for Agents
 


### PR DESCRIPTION
## Summary
Adds a comprehensive PR merge approval policy to project instructions to ensure future Claude sessions never auto-merge PRs without explicit user approval.

## Changes
- ✅ Added "PR Merge Approval Policy" section to CLAUDE.md with:
  - ⚠️ CRITICAL warning about never merging without approval
  - Required workflow steps (create → review → respond → STOP AND WAIT)
  - Clear examples of correct vs incorrect patterns
  - Explanation of why this policy exists
  - Command reference for PR operations

- ✅ Updated Memory.md with policy note in Important Notes section
  - Highly visible reminder for all future sessions

## Why This Change Is Important
Previously, Claude would sometimes auto-merge PRs after successful review without waiting for user approval. This policy:
- Maintains user control over the main branch
- Ensures user awareness of all merges
- Prevents unwanted changes from entering production
- Provides clear guidance for future AI sessions

## Testing
The policy has been documented in multiple locations for redundancy:
1. Main workflow section in CLAUDE.md
2. Dedicated PR Merge Approval Policy section
3. Memory.md Important Notes

## Related
Closes #252

*Note: This PR was created by an AI agent on behalf of the repository owner.*

**⚠️ IMPORTANT: Following the new policy, this PR will NOT be auto-merged. Awaiting explicit user approval before merging.**